### PR TITLE
Update ForgeRock dependencies to community edition

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -245,10 +245,16 @@
 				<version>${project.version}</version>
 			</dependency>
 			<dependency>
-                <groupId>edu.mit.ll.nics.tools</groupId>
-                <artifactId>openam-tools</artifactId>
-                <version>${project.version}</version>
-            </dependency>
+				<groupId>edu.mit.ll.nics.tools</groupId>
+				<artifactId>openam-tools</artifactId>
+				<version>${project.version}</version>
+				<exclusions>
+					<exclusion>
+						<groupId>javax.ws.rs</groupId>
+						<artifactId>jsr311-api</artifactId>
+					</exclusion>
+				</exclusions>
+			</dependency>
 			<dependency>
 				<groupId>javax.ws.rs</groupId>
 				<artifactId>javax.ws.rs-api</artifactId>


### PR DESCRIPTION
ForgeRock has removed access to compiled artifacts that are not "community edition". This broke the NICS build which was relying on these Maven artifacts. This pull request switches the build to use the latest community edition of OpenAM.

Depends on:
1stResponder/nics-tools/pull/1